### PR TITLE
simplify MSA algorithm + add some tests + typing + var names

### DIFF
--- a/simplified_msa.py
+++ b/simplified_msa.py
@@ -1,3 +1,5 @@
+import copy
+
 # Type for pairwise alignment
 PWA = tuple[str, str]
 
@@ -12,11 +14,14 @@ def has_gap_at_position(pwas: list[PWA], i: int) -> bool:
     return any(len(row[0]) > i and row[0][i] == "-" for row in pwas)
 
 
-def aligned_tuples_to_MSA(pwas: list[PWA]) -> list[str]:
+def aligned_tuples_to_MSA(pwas_input: list[PWA]) -> list[str]:
     """
     Convert a list of single alignments into a multisequence alignment.
     """
     i = 0
+
+    # Make a copy of the input to avoid modifying it in place
+    pwas = copy.deepcopy(pwas_input)
 
     while still_has_content(pwas, i):
 

--- a/simplified_msa.py
+++ b/simplified_msa.py
@@ -34,7 +34,7 @@ def aligned_tuples_to_MSA(pwas: list[PWA]) -> list[str]:
 
         i += 1
 
-    output = pwas[0][:1] + [sequence for _, sequence in pwas]
+    output = [pwas[0][0]] + [sequence for _, sequence in pwas]
 
     # Fill the potential gap at the end
     max_length = max(len(seq) for seq in output)

--- a/simplified_msa.py
+++ b/simplified_msa.py
@@ -1,68 +1,41 @@
-def still_has_content(data: list[list[str]], i: int) -> bool:
+# Type for pairwise alignment
+PWA = tuple[str, str]
+
+
+def still_has_content(pwas: list[PWA], i: int) -> bool:
     """Return True if any template string has length > i."""
-    return any(len(row[0]) > i for row in data)
+    return any(len(row[0]) > i for row in pwas)
 
 
-def has_gap_at_position(data: list[list[str]], i: int) -> bool:
+def has_gap_at_position(pwas: list[PWA], i: int) -> bool:
     """Return True if any alignment template has a '-' at position i."""
-    return any(len(row[0]) > i and row[0][i] == '-' for row in data)
+    return any(len(row[0]) > i and row[0][i] == "-" for row in pwas)
 
 
-def find_sequence_with_char_at_i(data: list[list[str]], i: int) -> str:
-    """Return the first character found at position i in any template."""
-    for row in data:
-        if len(row[0]) > i:
-            return row[0][i]
-
-
-def aligned_tuples_to_MSA(input_list: list[list[str]]) -> list[list[str]]:
+def aligned_tuples_to_MSA(pwas: list[PWA]) -> list[str]:
     """
     Convert a list of single alignments into a multisequence alignment.
     """
     i = 0
-    msa_ref = ""  # The final reference alignment string
-    nonref = ['' for _ in input_list]  # Accumulate the aligned sequences
 
-    while still_has_content(input_list, i):
+    while still_has_content(pwas, i):
 
         # If there's a gap in any template at position i
-        if has_gap_at_position(input_list, i):
-            # Add a gap to the reference sequence
-            msa_ref += '-'
+        if has_gap_at_position(pwas, i):
 
-            for j in range(len(input_list)):
-                template = input_list[j][0]
-                sequence = input_list[j][1]
-
-                # If the template has a gap at position i,
-                # add the corresponding character from the sequence
-                # to the nonref sequence
-                if len(template) > i and template[i] == '-':
-                    nonref[j] += sequence[i]
+            for j, (template, sequence) in enumerate(pwas):
 
                 # If the template has no gap at position i,
-                # add a gap to the nonref sequence
-                else:
-                    nonref[j] += '-'
-                    # Insert '-' in both template and sequence at position i
-                    # to maintain alignment with other templates
-                    input_list[j][0] = template[:i] + '-' + template[i:]
-                    input_list[j][1] = sequence[:i] + '-' + sequence[i:]
-
-        # If there's no gap in any template at position i
-        else:
-            # Take the character from any template to add to the reference
-            char = find_sequence_with_char_at_i(input_list, i)
-            msa_ref += char
-
-            for j in range(len(input_list)):
-                template = input_list[j][0]
-                sequence = input_list[j][1]
-
-                # Add the corresponding character to the nonref sequence
-                nonref[j] += sequence[i]
+                # Insert '-' in both template and sequence at position i
+                # to maintain alignment with other templates
+                if len(template) > i and template[i] != "-":
+                    pwas[j][0] = template[:i] + "-" + template[i:]
+                    pwas[j][1] = sequence[:i] + "-" + sequence[i:]
 
         i += 1
 
-    # Return reference and aligned sequences as a list of strings
-    return [msa_ref] + nonref
+    output = pwas[0][:1] + [sequence for _, sequence in pwas]
+
+    # Fill the potential gap at the end
+    max_length = max(len(seq) for seq in output)
+    return [seq + "-" * (max_length - len(seq)) for seq in output]

--- a/test_msa.py
+++ b/test_msa.py
@@ -21,27 +21,45 @@ input_data2 = [
     ]
 ]
 
+input_data3 = [["ata---", "ataaaa"], ["---ata", "aaaaca"]]
+
+# Same but adding flanking gaps in the first one only (a gap is kept in all in the MSA, but only at the end)
+input_data4 = [["-ata----", "-ataaaa-"], ["---ata", "aaaaca"]]
+
+# Flanking gaps in both (flanking gaps are present in the MSA as well on both start and end)
+input_data5 = [["-ata----", "-ataaaa-"], ["----ata-", "-aaaaca-"]]
+
 
 class TestTuplesToMSA(unittest.TestCase):
     def test_aligned_tuples_to_MSA_1(self):
         result1 = simplified_aligned_tuples_to_MSA(input_data1)
-        expected1 = [
-            "a-bcde-f-",
-            "aAb------",
-            "-Bbc-e-f-",
-            "----deEfF"
-        ]
+        expected1 = ["a-bcde-f-", "aAb------", "-Bbc-e-f-", "----deEfF"]
         self.assertEqual(result1, expected1)
-    
+
     def test_aligned_tuples_to_MSA_2(self):
         result1 = simplified_aligned_tuples_to_MSA(input_data2)
         expected1 = [
             "Today I w-oke up and went to my friend Manu--'s house for lunch",
             "Today I stood up-----------------------------------------------",
-            "-----------------------------my friend Cassie's house----------"
+            "-----------------------------my friend Cassie's house----------",
         ]
         self.assertEqual(result1, expected1)
 
-    
-if __name__ == '__main__':
+    def test_aligned_tuples_to_MSA_3(self):
+        result3 = simplified_aligned_tuples_to_MSA(input_data3)
+        expected3 = ["---ata---", "---ataaaa", "aaaaca---"]
+        self.assertEqual(result3, expected3)
+
+    def test_aligned_tuples_to_MSA_4(self):
+        result4 = simplified_aligned_tuples_to_MSA(input_data4)
+        expected4 = ["---ata----", "---ataaaa-", "aaaaca----"]
+        self.assertEqual(result4, expected4)
+
+    def test_aligned_tuples_to_MSA_5(self):
+        result5 = simplified_aligned_tuples_to_MSA(input_data5)
+        expected5 = ["----ata----", "----ataaaa-", "-aaaaca----"]
+        self.assertEqual(result5, expected5)
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hi @Cassiebastress I have simplified a bit the algorithm to build the MSA, have a look at the [changes](https://github.com/Cassiebastress/Task_Jan_20/pull/38/files) and let me know what you think, basically it keeps the core of what you were doing, but

* Instead of keeping a separate copy of msa_ref and nonref to return as an output, it uses the ones you edit in place in `input_list` as a return value
* That removes the need for the `else` statement and the `find_sequence_with_char_at_i `, but requires the extra padding with gaps at the end

In addition, I made some refactoring to improve clarity:

* In typing, to represent pwa (pairwise alignments) I used a `tuple` of 2 strings rather than a list, since there will always be 2 elements only. Also, you can create a name with this type, so I called PWA
* Rename `input_list` and `data` to a more specific variable name `pwas`
* Simplified using indexes and values at the same time in a loop by using enumerate:

```python
for j, (template, sequence) in enumerate(pwas):

# Instead of 
for j in range(len(input_list)):
                template = input_list[j][0]
                sequence = input_list[j][1]
```

I also added a few tests that I think show some behaviours we should be aware of. They are fine as they are, but it's good to know (`input_data4`, `input_data5`).

I will create an issue with a few more things to do

